### PR TITLE
Correct capitalization of Arduino.h

### DIFF
--- a/quadrature.h
+++ b/quadrature.h
@@ -1,7 +1,7 @@
 #ifndef QUADRATURE_H
 #define QUADRATURE_H OCT_2014
 
-#include <arduino.h>
+#include <Arduino.h>
 
 /*
    A quadrature encoder library for Arduino that takes


### PR DESCRIPTION
Incorrect capitalization caused compilation to fail on filename case sensitive operating systems such as Linux:
```
fatal error: arduino.h: No such file or directory
```
Fixes https://github.com/zacsketches/Encoder/issues/5